### PR TITLE
PLANET-2582 retrieve supporter fields from en

### DIFF
--- a/classes/controller/blocks/class-controller.php
+++ b/classes/controller/blocks/class-controller.php
@@ -116,6 +116,35 @@ if ( ! class_exists( 'Controller' ) ) {
 		abstract public function prepare_fields();
 
 		/**
+		 * Get all the data that will be needed to render the block correctly.
+		 *
+		 * @param array  $fields This is the array of fields of the block.
+		 * @param string $content This is the post content.
+		 * @param string $shortcode_tag The shortcode tag of the block.
+		 *
+		 * @return array The data to be passed in the View.
+		 */
+		abstract public function prepare_data( $fields, $content, $shortcode_tag ) : array;
+
+		/**
+		 * Callback for the shortcode.
+		 * It renders the shortcode based on supplied attributes.
+		 *
+		 * @param array  $fields This is the array of fields of this block.
+		 * @param string $content This is the post content.
+		 * @param string $shortcode_tag The shortcode tag of the block.
+		 *
+		 * @return string All the data used for the html.
+		 */
+		public function prepare_template( $fields, $content, $shortcode_tag ) : string {
+			$data = $this->prepare_data( $fields, $content, $shortcode_tag );
+			// Shortcode callbacks must return content, hence, output buffering here.
+			ob_start();
+			$this->view->block( static::BLOCK_NAME, $data );
+			return ob_get_clean();
+		}
+
+		/**
 		 * Output markup of an iframe to render shortcode when previewing in admin edit screen.
 		 *
 		 * We need to load through iframe to enqueue frontend styles without breaking admin ui
@@ -232,18 +261,6 @@ if ( ! class_exists( 'Controller' ) ) {
 			// Ajax callbacks need to call exit.
 			exit;
 		}
-
-		/**
-		 * Callback for the shortcode.
-		 * It renders the shortcode based on supplied attributes.
-		 *
-		 * @param array  $fields         Associative array of shortcode paramaters.
-		 * @param string $content        The content of the shortcode block for content wrapper shortcodes only.
-		 * @param string $shortcode_tag  The name of the shortcode.
-		 *
-		 * @return string                The html markup for the shortcode preview iframe
-		 */
-		abstract public function prepare_template( $fields, $content, $shortcode_tag ) : string;
 
 		/**
 		 * Validates and sanitizes the user input.

--- a/classes/controller/blocks/class-enform-controller.php
+++ b/classes/controller/blocks/class-enform-controller.php
@@ -74,25 +74,26 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 				],
 			];
 
-			$available_fields = $this->sync_fields();
+			// Get supporter fields from EN and use them on the fly.
+			$supporter_fields = $this->get_supporter_fields();
 
-			if ( $available_fields ) {
-				foreach ( $available_fields as $available_field ) {
+			if ( $supporter_fields ) {
+				foreach ( $supporter_fields as $supporter_field ) {
 					$attr_parts = [
-						$available_field['id'],
-						$available_field['name'],
-						( $available_field['mandatory'] ? 'true' : 'false' ),
-						str_replace( ' ', '-', $available_field['label'] ),
-						$available_field['type'],
+						$supporter_field['id'],
+						$supporter_field['name'],
+						( $supporter_field['mandatory'] ? 'true' : 'false' ),
+						str_replace( ' ', '-', $supporter_field['label'] ),
+						$supporter_field['type'],
 					];
 
 					$args = [
-						'label'       => $available_field['name'],
-						'description' => $available_field['label'],
+						'label'       => $supporter_field['name'],
+						'description' => $supporter_field['label'],
 						'attr'        => strtolower( implode( '_', $attr_parts ) ),
 						'type'        => 'checkbox',
 					];
-					if ( $available_field['mandatory'] ) {
+					if ( $supporter_field['mandatory'] ) {
 						$args['value'] = 'true';
 					}
 					$fields[] = $args;
@@ -151,11 +152,11 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 		}
 
 		/**
-		 * Sync supporter fields between EN and Planet4.
+		 * Retrieve supporter fields from EN and prepare them for use in P4.
 		 *
-		 * @return array Associative array of fields if sync was successful or empty array otherwise.
+		 * @return array Associative array of supporter fields if retrieval from EN was successful or empty array otherwise.
 		 */
-		public function sync_fields() : array {
+		public function get_supporter_fields() : array {
 			$main_settings = get_option( 'p4en_main_settings' );
 
 			if ( isset( $main_settings['p4en_private_api'] ) ) {
@@ -164,20 +165,20 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 				$response          = $ens_api->get_supporter_fields();
 
 				if ( is_array( $response ) && \WP_Http::OK === $response['response']['code'] && $response['body'] ) {
-					$supporter_fields = json_decode( $response['body'], true );
+					$en_supporter_fields = json_decode( $response['body'], true );
 
-					foreach ( $supporter_fields as $field_data ) {
-						if ( 'Not Tagged' !== $field_data['tag'] ) {
-							$available_fields[] = [
-								'id'        => $field_data['id'],
-								'name'      => $field_data['property'],
+					foreach ( $en_supporter_fields as $en_supporter_field ) {
+						if ( 'Not Tagged' !== $en_supporter_field['tag'] ) {
+							$supporter_fields[] = [
+								'id'        => $en_supporter_field['id'],
+								'name'      => $en_supporter_field['property'],
 								'mandatory' => false,
-								'label'     => $field_data['name'],
-								'type'      => strpos( $field_data['property'], 'country' ) === false ? 'text' : 'country',
+								'label'     => $en_supporter_field['name'],
+								'type'      => strpos( $en_supporter_field['property'], 'country' ) === false ? 'text' : 'country',
 							];
 						}
 					}
-					return $available_fields;
+					return $supporter_fields;
 				}
 			}
 			return [];

--- a/planet4-engagingnetworks.php
+++ b/planet4-engagingnetworks.php
@@ -62,10 +62,7 @@ require_once ABSPATH . 'wp-admin/includes/plugin.php';
       L O A D  P L U G I N
    ========================== */
 P4EN\Loader::get_instance( [
-	//'P4EN\Controllers\Menu\Pages_Standard_Controller',
 	'P4EN\Controllers\Menu\Pages_Datatable_Controller',
 	'P4EN\Controllers\Menu\Settings_Controller',
-	'P4EN\Controllers\Menu\Fields_Settings_Controller',
-	'P4EN\Controllers\Api\Rest_Controller',
 	'P4EN\Controllers\Blocks\ENForm_Controller',
 ], 'P4EN\Views\View' );


### PR DESCRIPTION
Retrieve supporter fields from EN on the fly and cache them in Redis for 10 minutes. Also, cached the response for the retrieved EN pages list used within the ENForm block. We no longer store the fields on P4. Disabled the Fields settings menu item (unused code is to be removed later on).