### PR TITLE
PLANET-3038 Add mandatory checkboxes for enganging networks fields in enform block

### DIFF
--- a/admin/css/admin_en.css
+++ b/admin/css/admin_en.css
@@ -10,3 +10,20 @@
     max-width: 25%;
     vertical-align: top;
 }
+
+.shortcode-ui-edit-shortcake_enform {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+div.shortcode-ui-edit-shortcake_enform > div {
+  padding-left: 2%;
+  flex: 0 20%;
+}
+
+div.shortcode-ui-edit-shortcake_enform > div:nth-child(-n+8) {
+  flex: 0 100%;
+}
+div.shortcode-ui-edit-shortcake_enform > div:nth-child(n+9):nth-child(even) {
+  margin-right: 40%;
+}

--- a/admin/js/en_ui.js
+++ b/admin/js/en_ui.js
@@ -1,11 +1,157 @@
-  jQuery(function ($) {
-    'use strict';
-  
-    if ('undefined' !== typeof (wp.shortcake)) {
-      shortcodeUIFieldData.p4en_radio = {
-        encode: false,
-        template: "shortcode-ui-field-p4-en-radio",
-        view: "editAttributeHeadingEN"
-      };
-    }
-  });
+jQuery(function ($) {
+  'use strict';
+
+  if ('undefined' !== typeof (wp.shortcake)) {
+    shortcodeUIFieldData.p4en_radio = {
+      encode: false,
+      template: "shortcode-ui-field-p4-en-radio",
+      view: "editAttributeHeadingEN"
+    };
+
+    var p4_en_blocks = {
+      enform: {
+
+        /**
+         * Called when a new enform block is rendered in the backend.
+
+         * @param shortcode Shortcake backbone model.
+         */
+        render_new: function (shortcode) {
+
+          // Get filtered fields.
+          var filtered = this.filter_enform_fields(shortcode);
+
+          // Hide all mandatory checkboxes for new enforms.
+          filtered.forEach(function (element) {
+            var attr_name = element.get("attr");
+            $("input[name='" + attr_name + "__mandatory']").parent().parent().hide();
+          });
+
+          this.add_click_events_for_filtered_fields(filtered);
+        },
+
+        /**
+         * Called when en existing enform block is rendered in the backend.
+
+         * @param shortcode Shortcake backbone model.
+         */
+        render_edit: function (shortcode) {
+
+          // Get filtered fields
+          var filtered = this.filter_enform_fields(shortcode);
+
+          // Hide all mandatory checkboxes for non selected en fields.
+          filtered.forEach(function (element) {
+            var attr_name = element.get("attr");
+            var $element = $("input[name='" + attr_name + "']");
+            if (!$element.is(':checked')) {
+              $("input[name='" + attr_name + "__mandatory']").parent().parent().hide();
+            }
+          });
+
+          this.add_click_events_for_filtered_fields(filtered);
+        },
+
+        /**
+         * Called when an enform block is destroyed in the backend.
+
+         * @param shortcode Shortcake backbone model.
+         */
+        render_destroy: function (shortcode) {
+
+          // Get filtered fields names.
+          var filtered = this.filter_enform_fields(shortcode);
+
+          // Remove click events for filtered en fields.
+          this.remove_click_events_for_filtered_fields(filtered);
+        },
+
+        /**
+         * Get en fields and questions checkboxes from an enform block.
+         *
+         * @param shortcode Shortcake backbone model.
+         */
+        filter_enform_fields: function (shortcode) {
+          return shortcode.attributes.attrs.filter(function (field) {
+            return field.get("attr").match(/^\d+_/) && !field.get("attr").match(/_mandatory$/);
+          });
+        },
+
+        get_filtered_names: function (filtered) {
+          return filtered.map(function (field) {
+            return field.get("attr");
+          });
+        },
+
+        /**
+         * Add click event handlers for all enform filtered fields, to show/hide their mandatory corresponding checkbox.
+         *
+         * @param filtered
+         */
+        add_click_events_for_filtered_fields: function (filtered) {
+
+          // Get filtered fields names.
+          var fields_names = this.get_filtered_names(filtered);
+
+          // Get jquery objects for each element.
+          var element_list = $.map(fields_names, function (el) {
+            return $("input[name='" + el + "']").get()
+          });
+
+          // Add click event handlers for the elements.
+          $(element_list).on('click', function (event) {
+            var element_name = event.currentTarget.name;
+            var $element = $(event.currentTarget);
+
+            if ($element.is(':checked')) {
+              $("input[name='" + element_name + "__mandatory']").parent().parent().show();
+            } else {
+              $("input[name='" + element_name + "__mandatory']").prop('checked', false).parent().parent().hide();
+            }
+          });
+        },
+
+        /**
+         * Remove click event handlers for all enform filtered fields.
+         *
+         * @param filtered
+         */
+        remove_click_events_for_filtered_fields: function (filtered) {
+
+          // Get filtered fields names.
+          var filtered_names = this.get_filtered_names(filtered);
+
+          // Remove click events for filtered en fields.
+          var filtered_objects = $.map(filtered_names, function (element_name) {
+            return $("input[name='" + element_name + "']").get()
+          });
+          $(filtered_objects).off('click');
+        }
+      }
+    };
+
+    // Attach hooks when rendering a new en block.
+    wp.shortcake.hooks.addAction('shortcode-ui.render_new', function (shortcode) {
+      if ('shortcake_enform' === shortcode.get('shortcode_tag')) {
+        // Call enform render new function.
+        p4_en_blocks.enform.render_new(shortcode);
+      }
+    });
+
+    // Attach hooks when destroying an en block.
+    wp.shortcake.hooks.addAction('shortcode-ui.render_destroy', function (shortcode) {
+      if ('shortcake_enform' === shortcode.get('shortcode_tag')) {
+        // Call enform render destroy function.
+        p4_en_blocks.enform.render_destroy(shortcode);
+      }
+    });
+
+    // Attach hooks when editing an existing en block.
+    wp.shortcake.hooks.addAction('shortcode-ui.render_edit', function (shortcode) {
+      if ('shortcake_enform' === shortcode.get('shortcode_tag')) {
+        // Call enform render edit function.
+        p4_en_blocks.enform.render_edit(shortcode);
+      }
+    });
+  }
+});

--- a/classes/controller/blocks/class-enform-controller.php
+++ b/classes/controller/blocks/class-enform-controller.php
@@ -51,12 +51,12 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 				return;
 			}
 
-			wp_enqueue_style( 'p4en_admin_style_blocks', P4EN_ADMIN_DIR . 'css/admin_en.css', [], '0.1' );
+			wp_enqueue_style( 'p4en_admin_style_blocks', P4EN_ADMIN_DIR . 'css/admin_en.css', [], '0.2' );
 			add_action(
 				'enqueue_shortcode_ui',
 				function () {
 					wp_enqueue_script( 'en-ui-heading-view', P4EN_ADMIN_DIR . 'js/en_ui_heading_view.js', [ 'shortcode-ui' ], '0.1', true );
-					wp_enqueue_script( 'en-ui', P4EN_ADMIN_DIR . 'js/en_ui.js', [ 'shortcode-ui' ], '0.1', true );
+					wp_enqueue_script( 'en-ui', P4EN_ADMIN_DIR . 'js/en_ui.js', [ 'shortcode-ui' ], '0.2', true );
 				}
 			);
 		}
@@ -212,7 +212,19 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 					if ( $supporter_field['mandatory'] ) {
 						$args['value'] = 'true';
 					}
+					$mandatory_attr_parts   = $attr_parts;
+					$mandatory_attr_parts[] = 'mandatory';
+					$args_mandatory         = [
+						'label'       => $supporter_field['name'] . '_mandatory',
+						'description' => 'Is "' . $supporter_field['label'] . '"" mandatory?',
+						'attr'        => strtolower( implode( '__', $mandatory_attr_parts ) ),
+						'type'        => 'checkbox',
+					];
+					if ( $supporter_field['mandatory'] ) {
+						$args['value'] = 'true';
+					}
 					$fields[] = $args;
+					$fields[] = $args_mandatory;
 				}
 			}
 
@@ -236,7 +248,18 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 						'attr'        => strtolower( implode( '__', $attr_parts ) ),
 						'type'        => 'checkbox',
 					];
+
+					$mandatory_attr_parts   = $attr_parts;
+					$mandatory_attr_parts[] = 'mandatory';
+					$args_mandatory         = [
+						'label'       => $supporter_question['label'] . '_mandatory',
+						'description' => 'Is "' . $supporter_question['label'] . '"" mandatory?',
+						'attr'        => strtolower( implode( '__', $mandatory_attr_parts ) ),
+						'type'        => 'checkbox',
+					];
+
 					$fields[] = $args;
+					$fields[] = $args_mandatory;
 				}
 			}
 


### PR DESCRIPTION
- Adds mandatory checkbox for each engaging networks field when rendering an enform block in the backend.
- Hides/show the mandatory checkbox if the relevant en field is selected.
_The mandatory fields are not passed to the frontend with this PR though._
[Issue 3038](https://jira.greenpeace.org/browse/PLANET-3038)