### PR TITLE
PLANET-3047 refactor enform shortcode

### DIFF
--- a/admin/js/en_ui.js
+++ b/admin/js/en_ui.js
@@ -35,7 +35,7 @@ jQuery(function ($) {
                   .attr('readonly', 'readonly')
                   .attr('onclick', 'return false;');
               $("input[name=" + attr_name + "__mandatory]")
-				  .click()
+                  .click()
                   .attr('readonly', 'readonly')
                   .attr('onclick',  'return false;')
                   .parent().parent().show();
@@ -57,13 +57,15 @@ jQuery(function ($) {
 
           // Hide all mandatory checkboxes for non selected en fields.
           filtered.forEach(function (element) {
-            let attr_name = element.get("attr");
-            let $element = $("input[name='" + attr_name + "']");
+            let attr_name    = element.get("attr");
+            let element_name = element.get("name");
+            let $element     = $("input[name='" + attr_name + "']");
 
             if (!$element.is(':checked')) {
               $("input[name='" + attr_name + "__mandatory']").parent().parent().hide();
             }
-            if ( $element.parent().text().indexOf( 'Email' ) >= 0 ) {
+
+            if ( 'emailAddress' === element_name ) {
               $element
                   .attr('readonly', 'readonly')
                   .attr('onclick',  'return false;');

--- a/admin/js/en_ui.js
+++ b/admin/js/en_ui.js
@@ -25,12 +25,20 @@ jQuery(function ($) {
           $("input[name$='__mandatory']").parent().parent().hide();
 
           filtered.forEach(function (element) {
-            let attr_name = element.get("attr");
-            let $element = $("input[name='" + attr_name + "']");
+            let attr_name    = element.get("attr");
+            let element_name = element.get("name");
+            let $element     = $("input[name='" + attr_name + "']");
 
-            if ( $element.parent().text().indexOf( 'Email' ) >= 0 ) {
-              $element.prop('checked', true).attr('disabled', 'disabled');
-              $("input[name=" + attr_name + "__mandatory]").prop('checked', true).attr('disabled', 'disabled').parent().parent().show();
+            if ( 'emailAddress' === element_name ) {
+              $element
+                  .click()  // Do click instead of setting checked property, because shortcake needs to catch the click event.
+                  .attr('readonly', 'readonly')
+                  .attr('onclick', 'return false;');
+              $("input[name=" + attr_name + "__mandatory]")
+				  .click()
+                  .attr('readonly', 'readonly')
+                  .attr('onclick',  'return false;')
+                  .parent().parent().show();
             }
           });
 
@@ -56,8 +64,13 @@ jQuery(function ($) {
               $("input[name='" + attr_name + "__mandatory']").parent().parent().hide();
             }
             if ( $element.parent().text().indexOf( 'Email' ) >= 0 ) {
-              $element.prop('checked', true).attr('disabled', 'disabled');
-              $("input[name=" + attr_name + "__mandatory]").prop('checked', true).attr('disabled', 'disabled').parent().parent().show();
+              $element
+                  .attr('readonly', 'readonly')
+                  .attr('onclick',  'return false;');
+              $("input[name=" + attr_name + "__mandatory]")
+                  .attr('readonly', 'readonly')
+                  .attr('onclick',  'return false;')
+                  .parent().parent().show();
             }
           });
 
@@ -114,6 +127,10 @@ jQuery(function ($) {
           $(element_list).on('click', function (event) {
             var element_name = event.currentTarget.name;
             var $element = $(event.currentTarget);
+
+            if ($element.attr('readonly') ) {
+              return false;
+            }
 
             if ($element.is(':checked')) {
               $("input[name='" + element_name + "__mandatory']").parent().parent().show();

--- a/admin/js/en_ui.js
+++ b/admin/js/en_ui.js
@@ -24,7 +24,7 @@ jQuery(function ($) {
           // Hide all mandatory checkboxes for new enforms.
           filtered.forEach(function (element) {
             var attr_name = element.get("attr");
-            $("input[name='" + attr_name + "__mandatory']").parent().parent().hide();
+            $("input[name$='__mandatory']").parent().parent().hide();
           });
 
           this.add_click_events_for_filtered_fields(filtered);
@@ -73,7 +73,7 @@ jQuery(function ($) {
          */
         filter_enform_fields: function (shortcode) {
           return shortcode.attributes.attrs.filter(function (field) {
-            return field.get("attr").match(/^\d+_/) && !field.get("attr").match(/_mandatory$/);
+            return ( field.get("attr").match(/^\d+/) || field.get("attr").match(/^field__+/) ) && !field.get("attr").match(/_mandatory$/);
           });
         },
 

--- a/admin/js/en_ui.js
+++ b/admin/js/en_ui.js
@@ -22,9 +22,16 @@ jQuery(function ($) {
           var filtered = this.filter_enform_fields(shortcode);
 
           // Hide all mandatory checkboxes for new enforms.
+          $("input[name$='__mandatory']").parent().parent().hide();
+
           filtered.forEach(function (element) {
-            var attr_name = element.get("attr");
-            $("input[name$='__mandatory']").parent().parent().hide();
+            let attr_name = element.get("attr");
+            let $element = $("input[name='" + attr_name + "']");
+
+            if ( $element.parent().text().indexOf( 'Email' ) >= 0 ) {
+              $element.prop('checked', true).attr('disabled', 'disabled');
+              $("input[name=" + attr_name + "__mandatory]").prop('checked', true).attr('disabled', 'disabled').parent().parent().show();
+            }
           });
 
           this.add_click_events_for_filtered_fields(filtered);
@@ -42,10 +49,15 @@ jQuery(function ($) {
 
           // Hide all mandatory checkboxes for non selected en fields.
           filtered.forEach(function (element) {
-            var attr_name = element.get("attr");
-            var $element = $("input[name='" + attr_name + "']");
+            let attr_name = element.get("attr");
+            let $element = $("input[name='" + attr_name + "']");
+
             if (!$element.is(':checked')) {
               $("input[name='" + attr_name + "__mandatory']").parent().parent().hide();
+            }
+            if ( $element.parent().text().indexOf( 'Email' ) >= 0 ) {
+              $element.prop('checked', true).attr('disabled', 'disabled');
+              $("input[name=" + attr_name + "__mandatory]").prop('checked', true).attr('disabled', 'disabled').parent().parent().show();
             }
           });
 

--- a/classes/controller/blocks/class-controller.php
+++ b/classes/controller/blocks/class-controller.php
@@ -185,10 +185,10 @@ if ( ! class_exists( 'Controller' ) ) {
 		public function ignore_unused_attributes( $fields ) : array {
 			// Filter out any attributes that are still inside the shortcode but are not being used by the block.
 			if ( $fields ) {
-				foreach ( $fields as $index => $value ) {
-					$fields_id = explode( '__', $index )[0];
-					if ( is_numeric( $fields_id ) && ! $value ) {
-						unset( $fields[ $index ] );
+				foreach ( $fields as $key => $value ) {
+					$attr_parts = explode( '__', $key );
+					if ( ( 'field' === $attr_parts[0] || is_numeric( $attr_parts[0] ) ) && ! $value ) {
+						unset( $fields[ $key ] );
 					}
 				}
 			}

--- a/classes/controller/blocks/class-enform-controller.php
+++ b/classes/controller/blocks/class-enform-controller.php
@@ -122,10 +122,10 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 					'options'     => $options,
 				],
 				[
-					'attr'              => 'en_form_style',
-					'label'             => __( 'What style of form do you need?', 'planet4-engagingnetworks' ),
-					'type'              => 'p4en_radio',
-					'options'           => [
+					'attr'        => 'en_form_style',
+					'label'       => __( 'What style of form do you need?', 'planet4-engagingnetworks' ),
+					'type'        => 'p4en_radio',
+					'options'     => [
 						[
 							'value' => 'full-width',
 							'label' => __( 'Full Width', 'planet4-engagingnetworks' ),
@@ -144,7 +144,7 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 					'label'       => __( 'Title', 'planet4-engagingnetworks' ),
 					'attr'        => 'title',
 					'type'        => 'text',
-					'meta'  => [
+					'meta'        => [
 						'placeholder' => __( 'Enter title', 'planet4-engagingnetworks' ),
 					],
 				],
@@ -152,7 +152,7 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 					'label'       => __( 'Description', 'planet4-engagingnetworks' ),
 					'attr'        => 'description',
 					'type'        => 'textarea',
-					'meta'  => [
+					'meta'        => [
 						'placeholder' => __( 'Enter description', 'planet4-engagingnetworks' ),
 					],
 				],
@@ -160,7 +160,7 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 					'label'       => __( 'Thank you Title', 'planet4-engagingnetworks' ),
 					'attr'        => 'thankyou_title',
 					'type'        => 'text',
-					'meta'  => [
+					'meta'        => [
 						'placeholder' => __( 'Enter Thank you Title', 'planet4-engagingnetworks' ),
 					],
 				],
@@ -168,7 +168,7 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 					'label'       => __( 'Thank you Subtitle', 'planet4-engagingnetworks' ),
 					'attr'        => 'thankyou_subtitle',
 					'type'        => 'text',
-					'meta'  => [
+					'meta'        => [
 						'placeholder' => __( 'Enter Thank you Subtitle', 'planet4-engagingnetworks' ),
 					],
 				],
@@ -176,7 +176,7 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 					'label'       => __( 'Thank you Url', 'planet4-engagingnetworks' ),
 					'attr'        => 'thankyou_url',
 					'type'        => 'url',
-					'meta'  => [
+					'meta'        => [
 						'placeholder' => __( 'Enter Thank you url', 'planet4-engagingnetworks' ),
 					],
 				],
@@ -203,7 +203,7 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 					];
 					$fields[] = $args;
 
-					$args_mandatory         = [
+					$args_mandatory = [
 						'label' => __( 'required', 'planet4-engagingnetworks' ),
 						'name'  => $supporter_field['name'] . '_mandatory',
 						'attr'  => $args['attr'] . '__mandatory',
@@ -275,7 +275,7 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 								'id'         => $attr_parts[0],
 								'questionId' => $attr_parts[1],
 								'mandatory'  => $fields[ $key . '__mandatory' ] ?? 'false',
-								'value'     => $value,
+								'value'      => $value,
 							];
 						}
 					}
@@ -369,7 +369,7 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 		 * @return array Associative array of supporter fields if retrieval from EN was successful or empty array otherwise.
 		 */
 		public function get_supporter_fields() : array {
-			// If we have not intialized yet the Ensapi_Controller then do it here.
+			// If we have not initialized yet the Ensapi_Controller then do it here.
 			if ( ! $this->ens_api ) {
 				$main_settings = get_option( 'p4en_main_settings' );
 				if ( isset( $main_settings['p4en_private_api'] ) ) {
@@ -388,15 +388,15 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 							$type = 'text';
 							if ( false !== strpos( $en_supporter_field['property'], 'country' ) ) {
 								$type = 'country';
-							} elseif ( false !== stripos( $en_supporter_field['property'], 'emailaddress' ) ) {
+							} elseif ( false !== strpos( $en_supporter_field['property'], 'emailAddress' ) ) {
 								$type = 'email';        // Set the type of the email input field as email.
 							}
 
 							$supporter_fields[] = [
-								'id'        => $en_supporter_field['id'],
-								'name'      => $en_supporter_field['property'],
-								'label'     => $en_supporter_field['name'],
-								'type'      => $type,
+								'id'    => $en_supporter_field['id'],
+								'name'  => $en_supporter_field['property'],
+								'label' => $en_supporter_field['name'],
+								'type'  => $type,
 							];
 						}
 					}

--- a/classes/controller/blocks/class-enform-controller.php
+++ b/classes/controller/blocks/class-enform-controller.php
@@ -56,7 +56,7 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 				'enqueue_shortcode_ui',
 				function () {
 					wp_enqueue_script( 'en-ui-heading-view', P4EN_ADMIN_DIR . 'js/en_ui_heading_view.js', [ 'shortcode-ui' ], '0.1', true );
-					wp_enqueue_script( 'en-ui', P4EN_ADMIN_DIR . 'js/en_ui.js', [ 'shortcode-ui' ], '0.2', true );
+					wp_enqueue_script( 'en-ui', P4EN_ADMIN_DIR . 'js/en_ui.js', [ 'shortcode-ui' ], '0.3', true );
 				}
 			);
 		}
@@ -195,35 +195,20 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 
 			if ( $supporter_fields ) {
 				foreach ( $supporter_fields as $supporter_field ) {
-					$attr_parts = [
-						$supporter_field['id'],
-						$supporter_field['name'],
-						( $supporter_field['mandatory'] ? 'true' : 'false' ),
-						str_replace( [ ' ', '?' ], [ '--', '-_-' ], $supporter_field['label'] ),
-						$supporter_field['type'],
-					];
-
 					$args = [
 						'label' => $supporter_field['label'],
 						'name'  => $supporter_field['name'],
-						'attr'  => strtolower( implode( '__', $attr_parts ) ),
+						'attr'  => 'field__' . $supporter_field['id'],
 						'type'  => 'checkbox',
 					];
-					if ( $supporter_field['mandatory'] ) {
-						$args['value'] = 'true';
-					}
-					$mandatory_attr_parts   = $attr_parts;
-					$mandatory_attr_parts[] = 'mandatory';
+					$fields[] = $args;
+
 					$args_mandatory         = [
 						'label' => __( 'required', 'planet4-engagingnetworks' ),
 						'name'  => $supporter_field['name'] . '_mandatory',
-						'attr'  => strtolower( implode( '__', $mandatory_attr_parts ) ),
+						'attr'  => $args['attr'] . '__mandatory',
 						'type'  => 'checkbox',
 					];
-					if ( $supporter_field['mandatory'] ) {
-						$args['value'] = 'true';
-					}
-					$fields[] = $args;
 					$fields[] = $args_mandatory;
 				}
 			}
@@ -234,31 +219,20 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 
 			if ( $supporter_questions ) {
 				foreach ( $supporter_questions as $supporter_question ) {
-					$attr_parts = [
-						$supporter_question['id'],
-						str_replace( [ ' ', '?' ], [ '--', '-_-' ], $supporter_question['name'] ),
-						$supporter_question['questionId'],
-						str_replace( [ ' ', '?' ], [ '--', '-_-' ], $supporter_question['label'] ),
-						$supporter_question['type'],
-					];
-
 					$args = [
 						'label'       => $supporter_question['label'],
 						'description' => 'GEN' === $supporter_question['type'] ? 'Question' : 'Opt-in',
-						'attr'        => strtolower( implode( '__', $attr_parts ) ),
+						'attr'        => $supporter_question['id'] . '__' . $supporter_question['questionId'],
 						'type'        => 'checkbox',
 					];
+					$fields[] = $args;
 
-					$mandatory_attr_parts   = $attr_parts;
-					$mandatory_attr_parts[] = 'mandatory';
 					$args_mandatory         = [
 						'label' => __( 'required', 'planet4-engagingnetworks' ),
 						'name'  => $supporter_question['name'] . '_mandatory',
-						'attr'  => strtolower( implode( '__', $mandatory_attr_parts ) ),
+						'attr'  => $args['attr'] . '__mandatory',
 						'type'  => 'checkbox',
 					];
-
-					$fields[] = $args;
 					$fields[] = $args_mandatory;
 				}
 			}
@@ -284,34 +258,50 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 		 * @return array The data to be passed in the View.
 		 */
 		public function prepare_data( $fields, $content, $shortcode_tag ) : array {
-			$fields    = $this->ignore_unused_attributes( $fields );
-			$questions = [];
+			$fields = $this->ignore_unused_attributes( $fields );
 
 			if ( $fields ) {
 				foreach ( $fields as $key => $value ) {
 					$attr_parts = explode( '__', $key );
-					if ( 5 === count( $attr_parts ) && is_numeric( $attr_parts[0] ) ) {
-						if ( 'gen' === $attr_parts[4] || 'opt' === $attr_parts[4] ) {
-							$questions[ $attr_parts[2] ] = [
+					if ( 'field' === $attr_parts[0] ) {
+						$fields[ $key ] = [
+							'id'        => $attr_parts[1],
+							'mandatory' => $fields[ $key . '__mandatory' ] ?? 'false',
+							'value'     => $value,
+						];
+					} else {
+						if ( is_numeric( $attr_parts[0] ) && 'mandatory' !== $attr_parts[ count( $attr_parts ) - 1 ] ) {
+							$fields[ $attr_parts[1] ] = [
 								'id'         => $attr_parts[0],
-								'name'       => $attr_parts[1],
-								'questionId' => $attr_parts[2],
-								'label'      => str_replace( [ '--', '-_-' ], [ ' ', '?' ], $attr_parts[3] ),
-								'type'       => $attr_parts[4],
-								'value'      => $value,
-								'mandatory'  => array_key_exists( $key . '__mandatory', $fields ) ? $fields[ $key . '__mandatory' ] : 'false',
-							];
-						} else {
-							$fields[ $key ] = [
-								'id'        => $attr_parts[0],
-								'name'      => $attr_parts[1],
-								'mandatory' => array_key_exists( $key . '__mandatory', $fields ) ? $fields[ $key . '__mandatory' ] : 'false',
-								'label'     => str_replace( [ '--', '-_-' ], [ ' ', '?' ], $attr_parts[3] ),
-								'type'      => $attr_parts[4],
+								'questionId' => $attr_parts[1],
+								'mandatory'  => $fields[ $key . '__mandatory' ] ?? 'false',
 								'value'     => $value,
 							];
 						}
 					}
+				}
+			}
+
+			// Get supporter fields from EN and use them on the fly.
+			$supporter_fields = $this->get_supporter_fields();
+			if ( $supporter_fields ) {
+				foreach ( $supporter_fields as $key => $supporter_field ) {
+					if ( isset( $fields[ 'field__' . $supporter_field['id'] ] ) ) {
+						$fields[ 'field__' . $supporter_field['id'] ] = array_merge( $fields[ 'field__' . $supporter_field['id'] ], $supporter_field );
+					}
+					unset( $supporter_fields[ $key ] );
+				}
+			}
+
+			// Get supporter questions from database.
+			$questions_model = new Questions_Model();
+			$questions       = $questions_model->get_questions();
+			if ( $questions ) {
+				foreach ( $questions as $key => $question ) {
+					if ( isset( $fields[ $question['questionId'] ] ) ) {
+						$questions[ $question['questionId'] ] = $question;
+					}
+					unset( $questions[ $key ] );
 				}
 			}
 
@@ -378,6 +368,14 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 		 * @return array Associative array of supporter fields if retrieval from EN was successful or empty array otherwise.
 		 */
 		public function get_supporter_fields() : array {
+			// If we have not intialized yet the Ensapi_Controller then do it here.
+			if ( ! $this->ens_api ) {
+				$main_settings = get_option( 'p4en_main_settings' );
+				if ( isset( $main_settings['p4en_private_api'] ) ) {
+					$ens_private_token = $main_settings['p4en_private_api'];
+					$this->ens_api     = new Ensapi( $ens_private_token );
+				}
+			}
 			if ( $this->ens_api ) {
 				$response = $this->ens_api->get_supporter_fields();
 
@@ -398,7 +396,6 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 								'name'      => $en_supporter_field['property'],
 								'label'     => $en_supporter_field['name'],
 								'type'      => $type,
-								//'mandatory' => false,
 							];
 						}
 					}
@@ -460,7 +457,7 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 		public function validate( $input ) : bool {
 			if (
 				( ! isset( $input['en_page_id'] ) || $input['en_page_id'] <= 0 ) ||
-				( ! isset( $input['supporter.emailaddress'] ) || false === filter_var( $input['supporter.emailaddress'], FILTER_VALIDATE_EMAIL ) )
+				( ! isset( $input['supporter.emailAddress'] ) || false === filter_var( $input['supporter.emailAddress'], FILTER_VALIDATE_EMAIL ) )
 			) {
 				return false;
 			}
@@ -474,7 +471,7 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 		 */
 		public function sanitize( &$input ) {
 			foreach ( $input as $key => $value ) {
-				if ( 'supporter.emailaddress' === $key ) {
+				if ( 'supporter.emailAddress' === $key ) {
 					$input[ $key ] = sanitize_email( $value );
 
 				} elseif ( false !== strpos( $key, 'supporter.question.' ) ) {  // Question/Optin name is in the form of 'supporter.question.{id}'.

--- a/classes/controller/blocks/class-enform-controller.php
+++ b/classes/controller/blocks/class-enform-controller.php
@@ -288,6 +288,7 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 				foreach ( $supporter_fields as $key => $supporter_field ) {
 					if ( isset( $fields[ 'field__' . $supporter_field['id'] ] ) ) {
 						$fields[ 'field__' . $supporter_field['id'] ] = array_merge( $fields[ 'field__' . $supporter_field['id'] ], $supporter_field );
+						unset( $fields[ 'field__' . $supporter_field['id'] . '__mandatory' ] );
 					}
 					unset( $supporter_fields[ $key ] );
 				}

--- a/classes/controller/class-ensapi-controller.php
+++ b/classes/controller/class-ensapi-controller.php
@@ -144,16 +144,16 @@ if ( ! class_exists( 'Ensapi_Controller' ) ) {
 			// inside the supporter key. Else a new supporter with this Email address will be created by EN.
 			$supporter_keys_fields = [
 				'Title'         => 'supporter.title',
-				'First name'    => 'supporter.firstname',
-				'Last name'     => 'supporter.lastname',
+				'First name'    => 'supporter.firstName',
+				'Last name'     => 'supporter.lastName',
 				'Address 1'     => 'supporter.address1',
 				'Address 2'     => 'supporter.address2',
 				'City'          => 'supporter.city',
 				'Country'       => 'supporter.country',
 				'Postcode'      => 'supporter.postcode',
-				'Email'         => 'supporter.emailaddress',
-				'Phone Number'  => 'supporter.phonenumber',
-				'date_of_birth' => 'supporter.dateofbirth',
+				'Email'         => 'supporter.emailAddress',
+				'Phone Number'  => 'supporter.phoneNumber',
+				'date_of_birth' => 'supporter.dateOfBirth',
 				'questions'     => 'supporter.questions',
 			];
 

--- a/includes/enform.twig
+++ b/includes/enform.twig
@@ -54,7 +54,7 @@
 													{% set value = supporter.County %}
 												{% elseif 'phone' in data.name %}
 													{% set value = supporter['Phone Number'] %}
-												{% elseif 'birth' in data.name %}
+												{% elseif 'Birth' in data.name %}
 													{% set value = supporter['date_of_birth'] %}
 												{% else %}
 													{% set value = '' %}
@@ -77,7 +77,7 @@
 																class="en__field__input en__field__input--text form-control"
 																value="{{ value }}"
 																data-errormessage="{{ errorMessage }}"
-																placeholder="{{ data.label }}{{ 'birth' in data.name ? ' (yyyy/mm/dd)' : '' }}"
+																placeholder="{{ data.label }}{{ 'Birth' in data.name ? ' (yyyy/mm/dd)' : '' }}"
 																{{ 'true' == data.mandatory or 'email' == data.type ? 'required' : '' }}
 																size="40" />
 														{% elseif 'country' == data.type %}
@@ -91,7 +91,7 @@
 									<br />
 									{% if supporter %}
 										{% for key,data in supporter.questions %}
-											{% if 'gen' == data.type %}
+											{% if 'GEN' == data.type %}
 												<div style="display: flex; flex-direction: row;">
 													<label for="en__field_supporter_questions_{{ data.id }}"
 														   class="en__field__label en__field__label--item form-check-label"
@@ -108,7 +108,7 @@
 										{% endfor %}
 										<br />
 										{% for key,data in supporter.questions %}
-											{% if 'opt' == data.type %}
+											{% if 'OPT' == data.type %}
 												<div class="form-check-label-block custom-control">
 													<input id="en__field_supporter_questions_{{ data.id }}"
 														   name="supporter.questions.{{ data.id }}"


### PR DESCRIPTION
Refactor the way we procude the ENForm block shortcode in order to simplify it and avoid issues related to fields/questions/optins labels or names containing chars that are not allowed within WP shortcode attributes or values.

Support Fields have attribute name in the form of `field__{field_id}`
Supporter Questions/Optins have attribute in the form of `{id}__{questionId}`