### PR TITLE
PLANET-3071: EN plugin: Make the API secret show as asteriscs (html type password)

### DIFF
--- a/includes/settings.twig
+++ b/includes/settings.twig
@@ -18,13 +18,23 @@
             <tr valign="top">
                 <th>{{ __( 'Public', domain ) }} API:</th>
                 <td>
-                    <input id="p4en_public_api" name="p4en_main_settings[p4en_public_api]" value="{{ settings.p4en_public_api|e('html_attr') }}" size="50" placeholder="{{ __( 'Enter your Engaging Networks account public token', domain ) }}" />
+                    <input type="password"
+                        id="p4en_public_api"
+                        name="p4en_main_settings[p4en_public_api]"
+                        value="{{ settings.p4en_public_api|e('html_attr') }}"
+                        size="50"
+                        placeholder="{{ __( 'Enter your Engaging Networks account public token', domain ) }}" />
                 </td>
             </tr>
             <tr valign="top">
                 <th>{{ __( 'Private', domain ) }} API:</th>
                 <td>
-                    <input id="p4en_private_api" name="p4en_main_settings[p4en_private_api]" value="{{ settings.p4en_private_api|e('html_attr') }}" size="50" placeholder="{{ __( 'Enter your Engaging Networks account private token', domain ) }}" />
+                    <input type="password"
+                        id="p4en_private_api"
+                        name="p4en_main_settings[p4en_private_api]"
+                        value="{{ settings.p4en_private_api|e('html_attr') }}"
+                        size="50"
+                        placeholder="{{ __( 'Enter your Engaging Networks account private token', domain ) }}" />
                 </td>
             </tr>
         </table>


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-3071

Using password type fields in EN settings page.