### PR TITLE
PLANET-3080 enblock required fields

### DIFF
--- a/admin/css/admin_en.css
+++ b/admin/css/admin_en.css
@@ -28,3 +28,7 @@ div.shortcode-ui-edit-shortcake_enform > div:nth-child(-n+9) {
 div.shortcode-ui-edit-shortcake_enform > div:nth-child(n+9):nth-child(odd) {
     margin-right: 40%;
 }
+
+.enform-required-field {
+    border-color: #ff3333 !important;
+}

--- a/admin/js/en_ui.js
+++ b/admin/js/en_ui.js
@@ -27,9 +27,12 @@ jQuery(function ($) {
           $("input[name$='__mandatory']").parent().parent().hide();
 
           filtered.forEach(function (element) {
-            let attr_name    = element.get("attr");
-            let element_name = element.get("name");
-            let $element     = $("input[name='" + attr_name + "']");
+            let attr_name        = element.get("attr");
+            let element_name     = element.get("name");
+            let $element         = $("input[name='" + attr_name + "']");
+            let $required_fields = $("[name$='_required']", $('.edit-shortcode-form'));
+
+            $required_fields.prop('required', true);
 
             if ( 'emailAddress' === element_name ) {
               $element
@@ -41,6 +44,14 @@ jQuery(function ($) {
                   .attr('readonly', 'readonly')
                   .attr('onclick',  'return false;')
                   .parent().parent().show();
+            }
+          });
+
+          $('input, textarea, select').filter('[required]:visible').off('change keyup').on('change keyup', function() {
+            if ( ! $(this).val() || ( $(this).is('select') && '0' === $(this).val() ) ) {
+              $(this).addClass('enform-required-field');
+            } else {
+              $(this).removeClass('enform-required-field');
             }
           });
 
@@ -64,6 +75,9 @@ jQuery(function ($) {
             let attr_name    = element.get("attr");
             let element_name = element.get("name");
             let $element     = $("input[name='" + attr_name + "']");
+            let $required_fields = $("[name$='_required']", $('.edit-shortcode-form'));
+
+            $required_fields.prop('required', true);
 
             if (!$element.is(':checked')) {
               $("input[name='" + attr_name + "__mandatory']").parent().parent().hide();
@@ -80,6 +94,14 @@ jQuery(function ($) {
             }
           });
 
+          $('input, textarea, select').filter('[required]:visible').off('change keyup').on('change keyup', function() {
+            if ( ! $(this).val() || ( $(this).is('select') && '0' === $(this).val() ) ) {
+              $(this).addClass('enform-required-field');
+            } else {
+              $(this).removeClass('enform-required-field');
+            }
+          });
+
           this.add_click_events_for_filtered_fields(filtered);
         },
 
@@ -89,6 +111,18 @@ jQuery(function ($) {
          * @param shortcode Shortcake backbone model.
          */
         render_destroy: function (shortcode) {
+          var flag = false;
+
+          $('input, textarea, select').filter('[required]:visible').each( function() {
+          	if ( ! $(this).val() || ( $(this).is('select') && '0' === $(this).val() ) ) {
+              flag = true;
+              $(this).addClass('enform-required-field');
+            }
+          });
+
+          if ( flag ) {
+            ;//throw new Error("Required field is empty!");
+          }
 
           // Get filtered fields names.
           var filtered = this.filter_enform_fields(shortcode);

--- a/admin/js/en_ui.js
+++ b/admin/js/en_ui.js
@@ -30,9 +30,6 @@ jQuery(function ($) {
             let attr_name        = element.get("attr");
             let element_name     = element.get("name");
             let $element         = $("input[name='" + attr_name + "']");
-            let $required_fields = $("[name$='_required']", $('.edit-shortcode-form'));
-
-            $required_fields.prop('required', true);
 
             if ( 'emailAddress' === element_name ) {
               $element
@@ -47,7 +44,10 @@ jQuery(function ($) {
             }
           });
 
-          $('input, textarea, select').filter('[required]:visible').off('change keyup').on('change keyup', function() {
+          let $required_fields = $("[name$='_required']", $('.edit-shortcode-form'));
+          $required_fields.prop('required', true);
+
+          $required_fields.off('change keyup').on('change keyup', function() {
             if ( ! $(this).val() || ( $(this).is('select') && '0' === $(this).val() ) ) {
               $(this).addClass('enform-required-field');
             } else {
@@ -75,9 +75,6 @@ jQuery(function ($) {
             let attr_name    = element.get("attr");
             let element_name = element.get("name");
             let $element     = $("input[name='" + attr_name + "']");
-            let $required_fields = $("[name$='_required']", $('.edit-shortcode-form'));
-
-            $required_fields.prop('required', true);
 
             if (!$element.is(':checked')) {
               $("input[name='" + attr_name + "__mandatory']").parent().parent().hide();
@@ -94,7 +91,10 @@ jQuery(function ($) {
             }
           });
 
-          $('input, textarea, select').filter('[required]:visible').off('change keyup').on('change keyup', function() {
+          let $required_fields = $("[name$='_required']", $('.edit-shortcode-form'));
+          $required_fields.prop('required', true);
+
+          $required_fields.off('change keyup').on('change keyup', function() {
             if ( ! $(this).val() || ( $(this).is('select') && '0' === $(this).val() ) ) {
               $(this).addClass('enform-required-field');
             } else {
@@ -121,7 +121,7 @@ jQuery(function ($) {
           });
 
           if ( flag ) {
-            ;//throw new Error("Required field is empty!");
+            throw new Error("Required field is empty!");
           }
 
           // Get filtered fields names.

--- a/admin/js/en_ui.js
+++ b/admin/js/en_ui.js
@@ -27,9 +27,9 @@ jQuery(function ($) {
           $("input[name$='__mandatory']").parent().parent().hide();
 
           filtered.forEach(function (element) {
-            let attr_name        = element.get("attr");
-            let element_name     = element.get("name");
-            let $element         = $("input[name='" + attr_name + "']");
+            let attr_name    = element.get("attr");
+            let element_name = element.get("name");
+            let $element     = $("input[name='" + attr_name + "']");
 
             if ( 'emailAddress' === element_name ) {
               $element

--- a/classes/controller/blocks/class-enform-controller.php
+++ b/classes/controller/blocks/class-enform-controller.php
@@ -64,12 +64,12 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 				return;
 			}
 
-			wp_enqueue_style( 'p4en_admin_style_blocks', P4EN_ADMIN_DIR . 'css/admin_en.css', [], '0.3' );
+			wp_enqueue_style( 'p4en_admin_style_blocks', P4EN_ADMIN_DIR . 'css/admin_en.css', [], '0.4' );
 			add_action(
 				'enqueue_shortcode_ui',
 				function () {
 					wp_enqueue_script( 'en-ui-heading-view', P4EN_ADMIN_DIR . 'js/en_ui_heading_view.js', [ 'shortcode-ui' ], '0.1', true );
-					wp_register_script( 'en-ui', P4EN_ADMIN_DIR . 'js/en_ui.js', [ 'shortcode-ui' ], '0.3', true );
+					wp_register_script( 'en-ui', P4EN_ADMIN_DIR . 'js/en_ui.js', [ 'shortcode-ui' ], '0.4', true );
 
 					// Localize en-ui script.
 					$translation_array = array(
@@ -141,7 +141,7 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 				[
 					'label'       => __( 'Engaging Network Live Pages', 'planet4-engagingnetworks' ),
 					'description' => $pages ? __( 'Select the Live EN page that this form will be submitted to.', 'planet4-engagingnetworks' ) : __( 'Check your EngagingNetworks settings!', 'planet4-engagingnetworks' ),
-					'attr'        => 'en_page_id',
+					'attr'        => 'en_page_id_required',
 					'type'        => 'select',
 					'options'     => $options,
 				],
@@ -459,8 +459,7 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 
 					if ( false === $fields ) {
 						$data['error_msg'] = __( 'Invalid input!', 'planet4-engagingnetworks' );
-					}
-					if ( $this->ens_api ) {
+					} elseif ( $this->ens_api ) {
 						$response = $this->ens_api->process_page( $fields['en_page_id'], $fields );
 						if ( is_array( $response ) && \WP_Http::OK === $response['response']['code'] && $response['body'] ) {
 							$data = json_decode( $response['body'], true );
@@ -491,7 +490,7 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 		 */
 		public function validate( $input ) : bool {
 			if (
-				( ! isset( $input['en_page_id'] ) || $input['en_page_id'] <= 0 ) ||
+				( ! isset( $input['en_page_id'] ) || '0' === $input['en_page_id'] ) ||
 				( ! isset( $input['supporter.emailAddress'] ) || false === filter_var( $input['supporter.emailAddress'], FILTER_VALIDATE_EMAIL ) )
 			) {
 				return false;

--- a/includes/enform.twig
+++ b/includes/enform.twig
@@ -20,7 +20,7 @@
 						<form id="p4en_form" name="p4en_form" method="post" novalidate>
 							{{ fn( 'wp_nonce_field', nonce_action, '_wpnonce', true, false )|raw }}
 							<input type="hidden" name="enform_submit" value="{{ enform_submit }}">
-							<input type="hidden" name="en_page_id" value="{{ fields.en_page_id }}">
+							<input type="hidden" name="en_page_id" value="{{ fields.en_page_id_required }}">
 							<input type="hidden" name="thankyou_title" value="{{ fields.thankyou_title }}">
 							<input type="hidden" name="thankyou_subtitle" value="{{ fields.thankyou_subtitle }}">
 
@@ -69,7 +69,7 @@
 												{% set errorMessage = __( 'Please select a country.', 'planet4-engagingnetworks' ) %}
 											{% endif %}
 
-											{% if 'en_page_id' != key and 'en_form_style' != key and '' != data.value %}
+											{% if 'en_page_id_required' != key and 'en_form_style' != key and '' != data.value %}
 												<div class="en__field en__field--{{ 'country' == data.type ? 'select' : 'text' }} en__field--{{ data.id }} en__field--{{ data.name }}">
 													<div class="en__field__element en__field__element--text form-group" style="display: block;">
 														{% if 'text' == data.type or 'email' == data.type %}


### PR DESCRIPTION
Add functionality to allow to set a block field as required (since currently this is not supported by Shortcake). Also, skip doing api call to EN if an EN page to send the data has not been selected.

So we can achieve this now by adding `_required` at the end of the `attr` of a shortcake field.