### PR TITLE
PLANET-3079 Admin EN Form block fields label changes

### DIFF
--- a/classes/controller/blocks/class-enform-controller.php
+++ b/classes/controller/blocks/class-enform-controller.php
@@ -192,7 +192,7 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 					'label' => __( 'Call to Action button (e.g. "Sign up now!")', 'planet4-engagingnetworks' ),
 					'attr'  => 'button_text_required',
 					'type'  => 'text',
-          'description' => 'Your default is set to [' . __( 'Sign', 'planet4-engagingnetworks' ) . ']',
+					'description' => 'Your default is set to [' . __( 'Sign', 'planet4-engagingnetworks' ) . ']',
 					'meta'  => [
 						'placeholder' => __( 'Enter the "Call to Action" button text', 'planet4-engagingnetworks' ),
 					],

--- a/classes/controller/blocks/class-enform-controller.php
+++ b/classes/controller/blocks/class-enform-controller.php
@@ -192,7 +192,6 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 					'label' => __( 'Call to Action button (e.g. "Sign up now!")', 'planet4-engagingnetworks' ),
 					'attr'  => 'button_text',
 					'type'  => 'text',
-					'description' => 'Your default is set to [' . __( 'Sign', 'planet4-engagingnetworks' ) . ']',
 					'meta'  => [
 						'placeholder' => __( 'Enter the "Call to Action" button text', 'planet4-engagingnetworks' ),
 						'required'    => '',

--- a/classes/controller/blocks/class-enform-controller.php
+++ b/classes/controller/blocks/class-enform-controller.php
@@ -190,11 +190,12 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 				],
 				[
 					'label' => __( 'Call to Action button (e.g. "Sign up now!")', 'planet4-engagingnetworks' ),
-					'attr'  => 'button_text_required',
+					'attr'  => 'button_text',
 					'type'  => 'text',
 					'description' => 'Your default is set to [' . __( 'Sign', 'planet4-engagingnetworks' ) . ']',
 					'meta'  => [
 						'placeholder' => __( 'Enter the "Call to Action" button text', 'planet4-engagingnetworks' ),
+						'required'    => '',
 					],
 				],
 				[

--- a/classes/controller/blocks/class-enform-controller.php
+++ b/classes/controller/blocks/class-enform-controller.php
@@ -181,23 +181,23 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 					],
 				],
 				[
-					'label' => __( 'Button text', 'planet4-engagingnetworks' ),
+					'label' => __( 'Call to Action button (e.g. "Sign up now!")', 'planet4-engagingnetworks' ),
 					'attr'  => 'button_text',
 					'type'  => 'text',
 					'meta'  => [
-						'placeholder' => __( 'Enter the text of the button', 'planet4-engagingnetworks' ),
+						'placeholder' => __( 'Enter the "Call to Action" button text', 'planet4-engagingnetworks' ),
 					],
 				],
 				[
-					'label' => __( 'Thank you Title', 'planet4-engagingnetworks' ),
+					'label' => __( '"Thank you" main text / Title (e.g. "Thank you for signing!")', 'planet4-engagingnetworks' ),
 					'attr'  => 'thankyou_title',
 					'type'  => 'text',
 					'meta'  => [
-						'placeholder' => __( 'Enter Thank you Title', 'planet4-engagingnetworks' ),
+						'placeholder' => __( 'Enter "Thank you" main text / Title ', 'planet4-engagingnetworks' ),
 					],
 				],
 				[
-					'label' => __( 'Thank you Subtitle', 'planet4-engagingnetworks' ),
+					'label' => __( '"Thank You" secondary message / Subtitle (e.g. "Your support means world")', 'planet4-engagingnetworks' ),
 					'attr'  => 'thankyou_subtitle',
 					'type'  => 'text',
 					'meta'  => [
@@ -205,11 +205,11 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 					],
 				],
 				[
-					'label' => __( 'Thank you Url', 'planet4-engagingnetworks' ),
+					'label' => __( '"Thank you page" url (Title and Subtitle will not be shown)', 'planet4-engagingnetworks' ),
 					'attr'  => 'thankyou_url',
 					'type'  => 'url',
 					'meta'  => [
-						'placeholder' => __( 'Enter Thank you url', 'planet4-engagingnetworks' ),
+						'placeholder' => __( 'Enter "Thank you page" url', 'planet4-engagingnetworks' ),
 					],
 				],
 			];


### PR DESCRIPTION
As per the latest [PR](https://github.com/greenpeace/planet4-plugin-engagingnetworks/pull/64) of Angelos the "CTA button" has added mandatory field validation by adding the `_required` at the end of the  `attr` of a shortcake field.