### PR TITLE
PLANET-3080 enblock required fields b

### DIFF
--- a/admin/js/en_ui.js
+++ b/admin/js/en_ui.js
@@ -44,10 +44,7 @@ jQuery(function ($) {
             }
           });
 
-          let $required_fields = $("[name$='_required']", $('.edit-shortcode-form'));
-          $required_fields.prop('required', true);
-
-          $required_fields.off('change keyup').on('change keyup', function() {
+          $('[required]:visible', $('.edit-shortcode-form')).off('change keyup').on('change keyup', function() {
             if ( ! $(this).val() || ( $(this).is('select') && '0' === $(this).val() ) ) {
               $(this).addClass('enform-required-field');
             } else {
@@ -91,10 +88,7 @@ jQuery(function ($) {
             }
           });
 
-          let $required_fields = $("[name$='_required']", $('.edit-shortcode-form'));
-          $required_fields.prop('required', true);
-
-          $required_fields.off('change keyup').on('change keyup', function() {
+          $('[required]:visible', $('.edit-shortcode-form')).off('change keyup').on('change keyup', function() {
             if ( ! $(this).val() || ( $(this).is('select') && '0' === $(this).val() ) ) {
               $(this).addClass('enform-required-field');
             } else {
@@ -111,16 +105,22 @@ jQuery(function ($) {
          * @param shortcode Shortcake backbone model.
          */
         render_destroy: function (shortcode) {
-          var flag = false;
+          var required_is_empty = false;
 
-          $('input, textarea, select').filter('[required]:visible').each( function() {
+          $('[required]:visible', $('.edit-shortcode-form')).each( function() {
           	if ( ! $(this).val() || ( $(this).is('select') && '0' === $(this).val() ) ) {
-              flag = true;
               $(this).addClass('enform-required-field');
+
+              if ( ! required_is_empty ) {
+                $(this).focus();
+              }
+              required_is_empty = true;
             }
           });
 
-          if ( flag ) {
+          // Here we have to prevent the block from Updating so the only way to do this at this point
+          // is to stop JS execution by throwing an error.
+          if ( required_is_empty ) {
             throw new Error("Required field is empty!");
           }
 

--- a/classes/controller/blocks/class-enform-controller.php
+++ b/classes/controller/blocks/class-enform-controller.php
@@ -69,7 +69,7 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 				'enqueue_shortcode_ui',
 				function () {
 					wp_enqueue_script( 'en-ui-heading-view', P4EN_ADMIN_DIR . 'js/en_ui_heading_view.js', [ 'shortcode-ui' ], '0.1', true );
-					wp_register_script( 'en-ui', P4EN_ADMIN_DIR . 'js/en_ui.js', [ 'shortcode-ui' ], '0.4', true );
+					wp_register_script( 'en-ui', P4EN_ADMIN_DIR . 'js/en_ui.js', [ 'shortcode-ui' ], '0.5', true );
 
 					// Localize en-ui script.
 					$translation_array = array(
@@ -141,8 +141,11 @@ if ( ! class_exists( 'ENForm_Controller' ) ) {
 				[
 					'label'       => __( 'Engaging Network Live Pages', 'planet4-engagingnetworks' ),
 					'description' => $pages ? __( 'Select the Live EN page that this form will be submitted to.', 'planet4-engagingnetworks' ) : __( 'Check your EngagingNetworks settings!', 'planet4-engagingnetworks' ),
-					'attr'        => 'en_page_id_required',
+					'attr'        => 'en_page_id',
 					'type'        => 'select',
+					'meta'        => [
+						'required' => '',
+					],
 					'options'     => $options,
 				],
 				[

--- a/includes/enform.twig
+++ b/includes/enform.twig
@@ -20,7 +20,7 @@
 						<form id="p4en_form" name="p4en_form" method="post" novalidate>
 							{{ fn( 'wp_nonce_field', nonce_action, '_wpnonce', true, false )|raw }}
 							<input type="hidden" name="enform_submit" value="{{ enform_submit }}">
-							<input type="hidden" name="en_page_id" value="{{ fields.en_page_id_required }}">
+							<input type="hidden" name="en_page_id" value="{{ fields.en_page_id }}">
 							<input type="hidden" name="thankyou_title" value="{{ fields.thankyou_title }}">
 							<input type="hidden" name="thankyou_subtitle" value="{{ fields.thankyou_subtitle }}">
 
@@ -69,7 +69,7 @@
 												{% set errorMessage = __( 'Please select a country.', 'planet4-engagingnetworks' ) %}
 											{% endif %}
 
-											{% if 'en_page_id_required' != key and 'en_form_style' != key and '' != data.value %}
+											{% if 'en_page_id' != key and 'en_form_style' != key and '' != data.value %}
 												<div class="en__field en__field--{{ 'country' == data.type ? 'select' : 'text' }} en__field--{{ data.id }} en__field--{{ data.name }}">
 													<div class="en__field__element en__field__element--text form-group" style="display: block;">
 														{% if 'text' == data.type or 'email' == data.type %}


### PR DESCRIPTION
- Use the Shortcake's meta key to pass element attributes to frontend (like required) instead of changing the fields attr names. So, in reality we only needed the missing frontend functionality (thanks @kirdia for pointing out).
- Focus on the first found empty required field.
- Add comment for future reference.
