### PR TITLE
PLANET-3404 EN forms custom post type list page

### DIFF
--- a/classes/controller/menu/class-enform-post-controller.php
+++ b/classes/controller/menu/class-enform-post-controller.php
@@ -13,11 +13,11 @@ if ( ! class_exists( 'Enform_Post_Controller' ) ) {
 	 * Class Enform_Post_Controller
 	 *
 	 * Creates and registers p4_en custom post type.
+	 * Also add filters for p4_en list page.
 	 */
 	class Enform_Post_Controller extends Controller {
 
 		const POST_TYPE = 'p4en_form';
-
 
 		/**
 		 * Hooks all the needed functions to load the class.
@@ -41,20 +41,18 @@ if ( ! class_exists( 'Enform_Post_Controller' ) ) {
 
 				add_submenu_page(
 					P4EN_PLUGIN_SLUG_NAME,
-					__( 'EN Forms', 'planet4-engagingnetworks' ),
-					__( 'EN Forms', 'planet4-engagingnetworks' ),
+					__( 'All EN Forms', 'planet4-engagingnetworks' ),
+					__( 'All EN Forms', 'planet4-engagingnetworks' ),
 					'edit_posts',
-					'admin.php?page=' . self::POST_TYPE,
-					''
+					'edit.php?post_type=' . self::POST_TYPE
 				);
 
 				add_submenu_page(
 					P4EN_PLUGIN_SLUG_NAME,
-					__( 'Add New EN Form', 'planet4-engagingnetworks' ),
-					__( 'Add New EN Form', 'planet4-engagingnetworks' ),
+					__( 'Add New', 'planet4-engagingnetworks' ),
+					__( 'Add New', 'planet4-engagingnetworks' ),
 					'edit_posts',
-					'admin.php?page=' . self::POST_TYPE . '-new',
-					''
+					'post-new.php?post_type=' . self::POST_TYPE
 				);
 
 			}
@@ -97,6 +95,11 @@ if ( ! class_exists( 'Enform_Post_Controller' ) ) {
 					'menu_position'       => null,
 					'exclude_from_search' => true,
 					'map_meta_cap'        => true,
+					// necessary in order to use WordPress default custom post type list page.
+					'show_ui'             => true,
+					// hide it from menu, as we are using custom submenu pages.
+					'show_in_menu'        => false,
+
 				]
 			);
 		}
@@ -106,8 +109,36 @@ if ( ! class_exists( 'Enform_Post_Controller' ) ) {
 		 */
 		private function hooks() {
 			add_action( 'init', [ $this, 'register_post_type' ] );
+			add_filter( 'post_row_actions', [ $this, 'modify_post_row_actions' ], 10, 2 );
 		}
 
+		/**
+		 * Filter for post_row_actions. Alters edit action link and removes Quick edit action.
+		 *
+		 * @param string[] $actions An array of row action links. Defaults are
+		 *                          'Edit', 'Quick Edit', 'Restore', 'Trash',
+		 *                          'Delete Permanently', 'Preview', and 'View'.
+		 * @param \WP_Post $post The post object.
+		 *
+		 * @return array  The filtered actions array.
+		 */
+		public function modify_post_row_actions( $actions, $post ) {
+
+			// Check if post is of p4en_form_post type.
+			if ( self::POST_TYPE === $post->post_type ) {
+
+				/*
+				 * Hide Quick Edit.
+				 */
+				$custom_actions = [
+					'inline hide-if-no-js' => '',
+				];
+
+				$actions = array_merge( $actions, $custom_actions );
+			}
+
+			return $actions;
+		}
 
 		/**
 		 * Validates the user input.


### PR DESCRIPTION
Modify p4en_form custom post type attributes to be able to use wordpress default post list page.
Add filters for p4en_form custom post type list page