### PR TITLE
PLANET-3405 add new page

### DIFF
--- a/admin/css/admin.css
+++ b/admin/css/admin.css
@@ -12,10 +12,10 @@
 :-ms-input-placeholder {
     font-style: italic;
 }
-.toplevel_page_engagingnetworks:not(.menu-top), .engagingnetworks_page_settings {
+.engagingnetworks_page_en-pages, .engagingnetworks_page_settings {
     background-color: #F1F1F1 !important;
 }
-.toplevel_page_engagingnetworks .submit {
+.engagingnetworks_page_en-pages .submit {
     display: inline;
 }
 #adminmenu .wp-menu-name, #adminmenu .current {

--- a/classes/class-loader.php
+++ b/classes/class-loader.php
@@ -216,7 +216,7 @@ if ( ! class_exists( 'Loader' ) ) {
 				wp_enqueue_script( 'p4en_datatables', 'https://cdn.datatables.net/1.10.15/js/jquery.dataTables.min.js', array( 'p4en_jquery' ), '1.10.15', true );
 				wp_enqueue_script( 'p4en_datatables_bootstrap', 'https://cdn.datatables.net/1.10.15/js/dataTables.bootstrap4.min.js', array( 'p4en_datatables' ), '1.10.15', true );
 			}
-			wp_enqueue_style( 'p4en_admin_style', P4EN_ADMIN_DIR . 'css/admin.css', array(), '0.2' );
+			wp_enqueue_style( 'p4en_admin_style', P4EN_ADMIN_DIR . 'css/admin.css', array(), '0.3' );
 			wp_enqueue_script( 'p4en_admin_script', P4EN_ADMIN_DIR . 'js/admin.js', array(), '0.2', true );
 		}
 

--- a/classes/controller/menu/class-enform-post-controller.php
+++ b/classes/controller/menu/class-enform-post-controller.php
@@ -99,7 +99,7 @@ if ( ! class_exists( 'Enform_Post_Controller' ) ) {
 					'rewrite'             => false,
 					'query_var'           => false,
 					'public'              => false,
-					'publicly_queryable'  => true,
+					'publicly_queryable'  => false,
 					'capability_type'     => 'page',
 					'has_archive'         => true,
 					'hierarchical'        => false,
@@ -144,7 +144,7 @@ if ( ! class_exists( 'Enform_Post_Controller' ) ) {
 		}
 
 		/**
-		 * Creates a Metabox on the side of the Add/Edit EN Form.
+		 * Creates a Meta box for the Selected Components of the current EN Form.
 		 *
 		 * @param \WP_Post $post The currently Added/Edited EN Form.
 		 */
@@ -161,26 +161,29 @@ if ( ! class_exists( 'Enform_Post_Controller' ) ) {
 		}
 
 		/**
+		 * Prepares data to render the Selected Components meta box.
+		 *
 		 * @param \WP_Post $post The currently Added/Edited EN Form.
 		 */
 		public function view_meta_box_selected( $post ) {
-			$this->view->selected_meta_box( [
-				'components' => [
-					[
-						'name'     => 'email',
-						'type'     => 'email',
-						'label'    => 'Email',
-						'value'    => 'example@example.com',
-						'required' => true,
-						'hidden'   => false,
+			$this->view->selected_meta_box(
+				[
+					'components' => [
+						[
+							'name'     => 'email',
+							'type'     => 'email',
+							'label'    => 'Email',
+							'value'    => 'example@example.com',
+							'required' => true,
+							'hidden'   => false,
+						],
 					],
-				],
-				'domain'     => 'planet4-engagingnetworks',
-			] );
+				]
+			);
 		}
 
 		/**
-		 *
+		 * Adds a meta box for the EN fields.
 		 */
 		public function add_fields_meta_box() {
 			$prefix = self::POST_TYPE . '-fields-';
@@ -195,10 +198,10 @@ if ( ! class_exists( 'Enform_Post_Controller' ) ) {
 
 			$meta_box->add_field(
 				[
-					'name' => __( 'Available Fields', 'planet4-engagingnetworks' ),
-					'desc' => __( 'Available EN Customer Fields', 'planet4-engagingnetworks' ),
-					'id'   => $prefix . 'name',
-					'type' => 'multicheck',
+					'name'    => __( 'Available Fields', 'planet4-engagingnetworks' ),
+					'desc'    => __( 'Available EN Customer Fields', 'planet4-engagingnetworks' ),
+					'id'      => $prefix . 'name',
+					'type'    => 'multicheck',
 					'options' => [
 						'check1' => 'Check One',
 						'check2' => 'Check Two',
@@ -209,7 +212,7 @@ if ( ! class_exists( 'Enform_Post_Controller' ) ) {
 		}
 
 		/**
-		 *
+		 * Adds a meta box for the EN questions.
 		 */
 		public function add_questions_meta_box() {
 			$prefix = self::POST_TYPE . '-questions-';
@@ -224,10 +227,10 @@ if ( ! class_exists( 'Enform_Post_Controller' ) ) {
 
 			$meta_box->add_field(
 				[
-					'name' => __( 'Available Questions', 'planet4-engagingnetworks' ),
-					'desc' => __( 'Available EN Customer Questions', 'planet4-engagingnetworks' ),
-					'id'   => $prefix . 'name',
-					'type' => 'multicheck',
+					'name'    => __( 'Available Questions', 'planet4-engagingnetworks' ),
+					'desc'    => __( 'Available EN Customer Questions', 'planet4-engagingnetworks' ),
+					'id'      => $prefix . 'name',
+					'type'    => 'multicheck',
 					'options' => [
 						'check1' => 'Check One',
 						'check2' => 'Check Two',
@@ -238,7 +241,7 @@ if ( ! class_exists( 'Enform_Post_Controller' ) ) {
 		}
 
 		/**
-		 *
+		 * Adds a meta box for the EN opt-ins.
 		 */
 		public function add_optins_meta_box() {
 			$prefix = self::POST_TYPE . '-optins-';

--- a/classes/controller/menu/class-enform-post-controller.php
+++ b/classes/controller/menu/class-enform-post-controller.php
@@ -23,11 +23,22 @@ if ( ! class_exists( 'Enform_Post_Controller' ) ) {
 		 * Hooks all the needed functions to load the class.
 		 */
 		public function load() {
-
 			parent::load();
-
 			// Register the hooks.
 			$this->hooks();
+		}
+
+		/**
+		 * Class hooks.
+		 */
+		private function hooks() {
+			add_action( 'init', [ $this, 'register_post_type' ] );
+			add_filter( 'post_row_actions', [ $this, 'modify_post_row_actions' ], 10, 2 );
+
+			add_action( 'add_meta_boxes', [ $this, 'add_meta_box_selected' ] );
+			add_action( 'cmb2_admin_init', [ $this, 'add_fields_meta_box' ] );
+			add_action( 'cmb2_admin_init', [ $this, 'add_questions_meta_box' ] );
+			add_action( 'cmb2_admin_init', [ $this, 'add_optins_meta_box' ] );
 		}
 
 		/**
@@ -88,7 +99,7 @@ if ( ! class_exists( 'Enform_Post_Controller' ) ) {
 					'rewrite'             => false,
 					'query_var'           => false,
 					'public'              => false,
-					'publicly_queryable'  => false,
+					'publicly_queryable'  => true,
 					'capability_type'     => 'page',
 					'has_archive'         => true,
 					'hierarchical'        => false,
@@ -99,17 +110,9 @@ if ( ! class_exists( 'Enform_Post_Controller' ) ) {
 					'show_ui'             => true,
 					// hide it from menu, as we are using custom submenu pages.
 					'show_in_menu'        => false,
-
+					'supports'            => [ 'title' ],
 				]
 			);
-		}
-
-		/**
-		 * Class hooks.
-		 */
-		private function hooks() {
-			add_action( 'init', [ $this, 'register_post_type' ] );
-			add_filter( 'post_row_actions', [ $this, 'modify_post_row_actions' ], 10, 2 );
 		}
 
 		/**
@@ -138,6 +141,129 @@ if ( ! class_exists( 'Enform_Post_Controller' ) ) {
 			}
 
 			return $actions;
+		}
+
+		/**
+		 * Creates a Metabox on the side of the Add/Edit EN Form.
+		 *
+		 * @param \WP_Post $post The currently Added/Edited EN Form.
+		 */
+		public function add_meta_box_selected( $post ) {
+			add_meta_box(
+				'meta-box-selected',
+				__( 'Selected Components', 'planet4-engagingnetworks' ),
+				[ $this, 'view_meta_box_selected' ],
+				[ self::POST_TYPE ],
+				'normal',
+				'high',
+				$post
+			);
+		}
+
+		/**
+		 * @param \WP_Post $post The currently Added/Edited EN Form.
+		 */
+		public function view_meta_box_selected( $post ) {
+			$this->view->selected_meta_box( [
+				'components' => [
+					[
+						'name'     => 'email',
+						'type'     => 'email',
+						'label'    => 'Email',
+						'value'    => 'example@example.com',
+						'required' => true,
+						'hidden'   => false,
+					],
+				],
+				'domain'     => 'planet4-engagingnetworks',
+			] );
+		}
+
+		/**
+		 *
+		 */
+		public function add_fields_meta_box() {
+			$prefix = self::POST_TYPE . '-fields-';
+
+			$meta_box = new_cmb2_box(
+				[
+					'id'           => $prefix . 'metabox',
+					'title'        => __( 'Fields', 'planet4-engagingnetworks' ),
+					'object_types' => [ self::POST_TYPE ],
+				]
+			);
+
+			$meta_box->add_field(
+				[
+					'name' => __( 'Available Fields', 'planet4-engagingnetworks' ),
+					'desc' => __( 'Available EN Customer Fields', 'planet4-engagingnetworks' ),
+					'id'   => $prefix . 'name',
+					'type' => 'multicheck',
+					'options' => [
+						'check1' => 'Check One',
+						'check2' => 'Check Two',
+						'check3' => 'Check Three',
+					],
+				]
+			);
+		}
+
+		/**
+		 *
+		 */
+		public function add_questions_meta_box() {
+			$prefix = self::POST_TYPE . '-questions-';
+
+			$meta_box = new_cmb2_box(
+				[
+					'id'           => $prefix . 'metabox',
+					'title'        => __( 'Questions', 'planet4-engagingnetworks' ),
+					'object_types' => [ self::POST_TYPE ],
+				]
+			);
+
+			$meta_box->add_field(
+				[
+					'name' => __( 'Available Questions', 'planet4-engagingnetworks' ),
+					'desc' => __( 'Available EN Customer Questions', 'planet4-engagingnetworks' ),
+					'id'   => $prefix . 'name',
+					'type' => 'multicheck',
+					'options' => [
+						'check1' => 'Check One',
+						'check2' => 'Check Two',
+						'check3' => 'Check Three',
+					],
+				]
+			);
+		}
+
+		/**
+		 *
+		 */
+		public function add_optins_meta_box() {
+			$prefix = self::POST_TYPE . '-optins-';
+
+			$meta_box = new_cmb2_box(
+				[
+					'id'           => $prefix . 'metabox',
+					'title'        => __( 'Opt-ins', 'planet4-engagingnetworks' ),
+					'object_types' => [ self::POST_TYPE ],
+				]
+			);
+
+			$meta_box->add_field(
+				[
+					'name' => __( 'Available Opt-ins', 'planet4-engagingnetworks' ),
+					'desc' => __( 'Available EN Customer Opt-ins', 'planet4-engagingnetworks' ),
+					'id'   => $prefix . 'name',
+					'type' => 'multicheck',
+					'options' => [
+						'check1' => 'Check One',
+						'check2' => 'Check Two',
+						'check3' => 'Check Three',
+					],
+				]
+			);
 		}
 
 		/**

--- a/classes/controller/menu/class-pages-datatable-controller.php
+++ b/classes/controller/menu/class-pages-datatable-controller.php
@@ -67,8 +67,17 @@ if ( ! class_exists( 'Pages_Datatable_Controller' ) ) {
 					'EngagingNetworks',
 					'edit_pages',
 					P4EN_PLUGIN_SLUG_NAME,
-					array( $this, 'prepare_pages_datatable' ),
+					'',
 					P4EN_ADMIN_DIR . 'images/logo_menu_page_16x16.jpg'
+				);
+
+				add_submenu_page(
+					P4EN_PLUGIN_SLUG_NAME,
+					'EngagingNetworks',
+					'EngagingNetworks',
+					'edit_pages',
+					'en-pages',
+					[ $this, 'prepare_pages_datatable' ]
 				);
 			}
 		}
@@ -143,8 +152,8 @@ if ( ! class_exists( 'Pages_Datatable_Controller' ) ) {
 		/**
 		 * Handle form submit.
 		 *
-		 * @param mixed[] $current_user The current user.
-		 * @param mixed[] $data The form data.
+		 * @param \WP_User $current_user The current user.
+		 * @param mixed[]  $data The form data.
 		 *
 		 * @return bool Array if validation is ok, false if validation fails.
 		 */

--- a/classes/view/class-view.php
+++ b/classes/view/class-view.php
@@ -122,7 +122,7 @@ if ( ! class_exists( 'View' ) ) {
 		}
 
 		/**
-		 * Render the settings page of the plugin.
+		 * Render the Selected Components meta box for EN Forms.
 		 *
 		 * @param array $data All the data needed to render the template.
 		 */

--- a/classes/view/class-view.php
+++ b/classes/view/class-view.php
@@ -122,6 +122,15 @@ if ( ! class_exists( 'View' ) ) {
 		}
 
 		/**
+		 * Render the settings page of the plugin.
+		 *
+		 * @param array $data All the data needed to render the template.
+		 */
+		public function selected_meta_box( $data ) {
+			$this->view_template( __FUNCTION__, $data );
+		}
+
+		/**
 		 * Displays a message.
 		 *
 		 * @param array $data All the data needed to render the template.

--- a/includes/selected_meta_box.twig
+++ b/includes/selected_meta_box.twig
@@ -1,0 +1,46 @@
+{% block selected_meta_box %}
+	<table id="en_form_selected_fields_table" class="table table-striped table-bordered" cellspacing="0" width="100%">
+		<thead>
+		<tr valign="top">
+			<th>{{ __( 'Name', domain ) }}</th>
+			<th>{{ __( 'Hidden', domain ) }}</th>
+			<th>{{ __( 'Required', domain ) }}</th>
+			<th>{{ __( 'Label', domain ) }}</th>
+			<th>{{ __( 'Type', domain ) }}</th>
+			<th>{{ __( 'Value', domain ) }}</th>
+		</tr>
+		</thead>
+		<tfoot>
+		<tr valign="top">
+			<th>{{ __( 'Name', domain ) }}</th>
+			<th>{{ __( 'Hidden', domain ) }}</th>
+			<th>{{ __( 'Required', domain ) }}</th>
+			<th>{{ __( 'Label', domain ) }}</th>
+			<th>{{ __( 'Type', domain ) }}</th>
+			<th>{{ __( 'Value', domain ) }}</th>
+		</tr>
+		</tfoot>
+		{% for component in components %}
+			<tr valign="top">
+				<td>
+					{{ component.name }}
+				</td>
+				<td>
+					{{ component.hidden }}
+				</td>
+				<td>
+					{{ component.required }}
+				</td>
+				<td>
+					{{ component.label }}
+				</td>
+				<td>
+					{{ component.type }}
+				</td>
+				<td>
+					{{ component.value }}
+				</td>
+			</tr>
+		{% endfor %}
+	</table>
+{% endblock %}

--- a/includes/selected_meta_box.twig
+++ b/includes/selected_meta_box.twig
@@ -2,22 +2,22 @@
 	<table id="en_form_selected_fields_table" class="table table-striped table-bordered" cellspacing="0" width="100%">
 		<thead>
 		<tr valign="top">
-			<th>{{ __( 'Name', domain ) }}</th>
-			<th>{{ __( 'Hidden', domain ) }}</th>
-			<th>{{ __( 'Required', domain ) }}</th>
-			<th>{{ __( 'Label', domain ) }}</th>
-			<th>{{ __( 'Type', domain ) }}</th>
-			<th>{{ __( 'Value', domain ) }}</th>
+			<th>{{ __( 'Name', 'planet4-engagingnetworks' ) }}</th>
+			<th>{{ __( 'Hidden', 'planet4-engagingnetworks' ) }}</th>
+			<th>{{ __( 'Required', 'planet4-engagingnetworks' ) }}</th>
+			<th>{{ __( 'Label', 'planet4-engagingnetworks' ) }}</th>
+			<th>{{ __( 'Type', 'planet4-engagingnetworks' ) }}</th>
+			<th>{{ __( 'Value', 'planet4-engagingnetworks' ) }}</th>
 		</tr>
 		</thead>
 		<tfoot>
 		<tr valign="top">
-			<th>{{ __( 'Name', domain ) }}</th>
-			<th>{{ __( 'Hidden', domain ) }}</th>
-			<th>{{ __( 'Required', domain ) }}</th>
-			<th>{{ __( 'Label', domain ) }}</th>
-			<th>{{ __( 'Type', domain ) }}</th>
-			<th>{{ __( 'Value', domain ) }}</th>
+			<th>{{ __( 'Name', 'planet4-engagingnetworks' ) }}</th>
+			<th>{{ __( 'Hidden', 'planet4-engagingnetworks' ) }}</th>
+			<th>{{ __( 'Required', 'planet4-engagingnetworks' ) }}</th>
+			<th>{{ __( 'Label', 'planet4-engagingnetworks' ) }}</th>
+			<th>{{ __( 'Type', 'planet4-engagingnetworks' ) }}</th>
+			<th>{{ __( 'Value', 'planet4-engagingnetworks' ) }}</th>
 		</tr>
 		</tfoot>
 		{% for component in components %}

--- a/planet4-engagingnetworks.php
+++ b/planet4-engagingnetworks.php
@@ -99,12 +99,12 @@ require_once ABSPATH . 'wp-admin/includes/plugin.php';
  */
 P4EN\Loader::get_instance(
 	[
+		'P4EN\Controllers\Menu\Enform_Post_Controller',
 		'P4EN\Controllers\Menu\Pages_Datatable_Controller',
 		'P4EN\Controllers\Menu\Settings_Controller',
 		'P4EN\Controllers\Blocks\ENForm_Controller',
 		'P4EN\Controllers\Menu\Questions_Settings_Controller',
 		'P4EN\Controllers\Api\Rest_Controller',
-		'P4EN\Controllers\Menu\Enform_Post_Controller',
 	],
 	'P4EN\Views\View'
 );


### PR DESCRIPTION
First implementation of the EN Form Add/Edit page. Can save/load dummy fields. Re-arranged the sub-menu items to resemble WP's Post/Page sub-menu items order.