### PR TITLE
PLANET-3554 Render hidden enform fields properly

### DIFF
--- a/includes/enform_post.twig
+++ b/includes/enform_post.twig
@@ -2,11 +2,10 @@
 
 	{# Render enform's hidden fields #}
 	{% for key, field in form_fields %}
-		<div>
-			{% if 'hidden' == field.input_type %}
-				<input type="hidden" name="{{ field.input_name }}" value="{{ field.default_value }}"/>
-			{% endif %}
-		</div>
+		{% if 'hidden' == field.input_type and 'Field' == field.en_type %}
+			{% set en_input_name = 'supporter.'~field.property %}
+			<input type="hidden" name="{{ en_input_name }}" value="{{ field.default_value|e('html_attr') }}"/>
+		{% endif %}
 	{% endfor %}
 
 	<div class="formblock-flex donations-formsection-info">


### PR DESCRIPTION
Render hidden enform fields with input name as needed for en api requests.
Also escape the value set for the hidden field.

needed format:
`supporter.field_property`