### PR TITLE
PLANET-3576 Auto-add email field in new enform posts

### DIFF
--- a/admin/js/enforms.js
+++ b/admin/js/enforms.js
@@ -123,6 +123,7 @@ var p4_enform = (function ($) {
       _.each(this.collection.models, function (project) {
         this.renderOne(project);
       }, this);
+      this.disableEmailField();
     },
 
     /**
@@ -149,6 +150,15 @@ var p4_enform = (function ($) {
     updateSort: function (event, model, position) {
       this.collection.remove(model, {silent: true}); //
       this.collection.add(model, {at: position, silent: true});
+    },
+
+    /**
+     * Disable email field attributes besides label.
+     */
+    disableEmailField: function () {
+      $('tr[data-en-name="Email"] span.remove-en-field').remove();
+      $('tr[data-en-name="Email"] input[data-attribute="required"]').prop('checked', true).prop('disabled', true);
+      $('tr[data-en-name="Email"] select[data-attribute="input_type"]').val('email').prop('disabled', true);
     }
   });
 
@@ -414,6 +424,11 @@ var p4_enform = (function ($) {
         fields_arr.push(new app.Models.EnformField(field));
       }, this);
       app.fields.add(fields_arr);
+    }
+
+    // If it is a new post, add email field.
+    if ('auto-draft' === $('#original_post_status').val()) {
+      $('button[class="add-en-field"][data-property="emailAddress"] ').click();
     }
 
     app.fields_view = new app.Views.FieldsListView({collection: app.fields});

--- a/classes/controller/class-enform-fields-list-table.php
+++ b/classes/controller/class-enform-fields-list-table.php
@@ -142,9 +142,6 @@ class Enform_Fields_List_Table extends \WP_List_Table {
 	 * @see \WP_List_Table::display_tablenav
 	 */
 	protected function display_tablenav( $which ) {
-		esc_html_e( 'Only tagged fields are listed here', 'planet4-engagingnetworks' );
-		echo '<br/><br/>';
-
 		if ( ! empty( $this->error ) && 'top' === $which ) {
 			echo '<div><p>' . esc_html( $this->error ) . '</p></div>';
 		}

--- a/classes/controller/menu/class-enform-post-controller.php
+++ b/classes/controller/menu/class-enform-post-controller.php
@@ -364,7 +364,7 @@ if ( ! class_exists( 'Enform_Post_Controller' ) ) {
 					'jquery',
 					'wp-backbone',
 				],
-				'0.4',
+				'0.6',
 				true
 			);
 		}


### PR DESCRIPTION
Auto-add email field in 'Add New' enform page.
Remove obsolete message about non-tagged fields in fields list table.