### PR TITLE
PLANET-3401 Remove the menu items that are not relevant to version 2

### DIFF
--- a/classes/controller/menu/class-pages-datatable-controller.php
+++ b/classes/controller/menu/class-pages-datatable-controller.php
@@ -70,15 +70,6 @@ if ( ! class_exists( 'Pages_Datatable_Controller' ) ) {
 					'',
 					P4EN_ADMIN_DIR . 'images/logo_menu_page_16x16.jpg'
 				);
-
-				add_submenu_page(
-					P4EN_PLUGIN_SLUG_NAME,
-					__( 'EN Pages', 'planet4-engagingnetworks' ),
-					__( 'EN Pages', 'planet4-engagingnetworks' ),
-					'edit_pages',
-					'en-pages',
-					[ $this, 'prepare_pages_datatable' ]
-				);
 			}
 		}
 

--- a/classes/controller/menu/class-questions-settings-controller.php
+++ b/classes/controller/menu/class-questions-settings-controller.php
@@ -18,17 +18,7 @@ if ( ! class_exists( 'Questions_Settings_Controller' ) ) {
 		 * Create menu/submenu entry.
 		 */
 		public function create_admin_menu() {
-
-			if ( current_user_can( 'manage_options' ) ) {
-				add_submenu_page(
-					P4EN_PLUGIN_SLUG_NAME,
-					__( 'Questions Settings', 'planet4-engagingnetworks' ),
-					__( 'Questions Settings', 'planet4-engagingnetworks' ),
-					'manage_options',
-					'questions-settings',
-					[ $this, 'prepare_page' ]
-				);
-			}
+			
 		}
 
 		/**


### PR DESCRIPTION
This only removes the two menu items from the admin pages, since they are not relevant to version 2. 
It does not remove the functionality completely. 