### PR TITLE
PLANET-3598 add radio type

### DIFF
--- a/includes/enform_post.twig
+++ b/includes/enform_post.twig
@@ -81,6 +81,27 @@
 							</label>
 						</div>
 					</div>
+				{% elseif 'radio' == field.input_type %}
+					<div class="en__field en__field--check en__field--{{ field.id }}">
+						<div class="en__field__element en__field__element--check form-group form-check-label-block custom-control p4-custom-control-input">
+							<label class="custom-radio">
+								{% for value, label in field.radio_options %}
+								<input
+										id="en__field_supporter_{{ field.name }}"
+										name="{{ en_input_name }}"
+										type="radio"
+										class="en__field__input en__field__input--radio"
+										value="{{ value }}"
+										data-errormessage="{{ errorMessage }}"
+										{{ 'true' == field.required ? 'required' : '' }}
+								/> {{ label }}
+								{% endfor %}
+								<span class="custom-control-description">
+									{{ field.label|e('wp_kses_post')|raw }}{{ 'true' == field.required ? '*' : '' }}
+								</span>
+							</label>
+						</div>
+					</div>
 				{% elseif 'country' == field.input_type %}
 					<div class="en__field en__field--select en__field--{{ field.id }}">
 						<div class="en__field__element en__field__element--select form-group">

--- a/includes/selected_enform_fields.twig
+++ b/includes/selected_enform_fields.twig
@@ -21,6 +21,7 @@
 				<option value="email"  <% print( input_type == 'email' ?  'selected': '') %> >{{ __( 'Email', 'planet4-engagingnetworks' ) }}</option>
 				<option value="hidden"  <% print( input_type == 'hidden' ?  'selected': '') %> >{{ __( 'Hidden', 'planet4-engagingnetworks' ) }}</option>
 				<option value="text"  <% print( input_type == 'text' ?  'selected': '') %> >{{ __( 'Text', 'planet4-engagingnetworks' ) }}</option>
+				<option value="radio"  <% print( input_type == 'radio' ?  'selected': '') %> >{{ __( 'Radio', 'planet4-engagingnetworks' ) }}</option>
 			</select>
 		</td>
 		<td class="actions">
@@ -86,6 +87,26 @@
 			</div>
 			<br /><strong>{{ __( 'Opt-in label', 'planet4-engagingnetworks' ) }}</strong>
 			<br /><label class="question-label"></label>
+		</p>
+	</div>
+</script>
+
+<script type="text/html" id="tmpl-en-question-radio-dialog">
+	<div style="display: none;" class="dialog" data-en-id="<%= id %>">
+		<p>{{ __( 'Opt-in Radio customization', 'planet4-engagingnetworks' ) }}</p>
+		<p>
+			<label class="control-label">{{ __( 'Radio Question Label', 'planet4-engagingnetworks' ) }}</label>
+		<div>
+			<% _.each( radio_options, function( radio_text, radio_value ) { %>
+			<input
+					id="en__field_supporter_{{ field.name }}"
+					type="radio"
+					class="en__field__input en__field__input--radio"
+					value="<%= radio_value %>"
+					data-errormessage="{{ errorMessage }}"
+			/> <%= radio_text %>
+			<% }); %>
+		</div>
 		</p>
 	</div>
 </script>


### PR DESCRIPTION
Added Radio type option. Retrieve radio options for Opt-ins. Show radio options inside the Edit modal.

Since, I did some code work in order to be able to test what we can do with the Radio field type of the Optins I thought I should push it in case someone else wants to pick it up after we get some feedback on what exactly to do.
For more information, read [here](https://jira.greenpeace.org/browse/PLANET-3598?focusedCommentId=149491&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-149491)