### PR TITLE
PLANET-3897: CPP - Too Much space between navigation bar and Left hand title text.

### DIFF
--- a/assets/scss/components/_enform.scss
+++ b/assets/scss/components/_enform.scss
@@ -41,7 +41,7 @@
 
   @include large-and-up {
     float: left;
-    padding-top: 176px;
+    padding-top: 117px;
     width: 50%;
     padding-left: 0;
     padding-right: 0;


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-3897