### PR TITLE
PLANET-4008 EN Block: modify campaign_logo default value

### DIFF
--- a/classes/controller/blocks/class-enblock-controller.php
+++ b/classes/controller/blocks/class-enblock-controller.php
@@ -249,7 +249,7 @@ if ( ! class_exists( 'ENBlock_Controller' ) ) {
 					'label' => __( 'Use Campaign Logo?', 'planet4-engagingnetworks' ),
 					'attr'  => 'campaign_logo',
 					'type'  => 'checkbox',
-					'value' => 'false',
+					'value' => '',
 				],
 				[
 					'label' => __( 'Content Title', 'planet4-engagingnetworks' ),


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-4008

This is needed so that field is not part of the generated shortcode if not checked.