### PR TITLE
PLANET-4029 Don't Reset label field when p4 field type is changed

### DIFF
--- a/admin/js/enforms.js
+++ b/admin/js/enforms.js
@@ -313,7 +313,6 @@ const p4_enform = (function ($) {
 
       this.model.set(attr, input_type);
       $tr.find('.dashicons-edit').parent().remove();
-      $label.val('').trigger('change');
 
       switch ( input_type ) {
       case 'checkbox':
@@ -340,6 +339,7 @@ const p4_enform = (function ($) {
       case 'hidden':
         $required.prop('checked', false).trigger('change').prop('disabled', true);
         $label.prop('disabled', true);
+        $label.val('').trigger('change');
         this.$el.find('.actions').prepend('<a><span class="dashicons dashicons-edit pointer"></span></a>');
         this.createFieldDialog();
         break;

--- a/classes/controller/menu/class-enform-post-controller.php
+++ b/classes/controller/menu/class-enform-post-controller.php
@@ -385,7 +385,7 @@ if ( ! class_exists( 'Enform_Post_Controller' ) ) {
 					'jquery',
 					'wp-backbone',
 				],
-				'0.9.1',
+				'0.9.2',
 				true
 			);
 		}


### PR DESCRIPTION
Reset label field only when p4 field type is set to hidden.
Label would still be reset for 'checkbox', 'radio' types (which is required for opt-ins and questions)